### PR TITLE
fix(CPU): Ignore second core in core_map for a given core_id when SMT is disabled.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerstation"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "libryzenadj",
  "log",

--- a/src/performance/cpu/core.rs
+++ b/src/performance/cpu/core.rs
@@ -7,6 +7,7 @@ use zbus::fdo;
 use zbus_macros::dbus_interface;
 
 // Instance of a single CPU core
+#[derive(Debug)]
 pub struct CPUCore {
     // CPU core number
     pub number: u32,


### PR DESCRIPTION
- Fixes bug where the disabled SMT core would attempt (and fail) to enable when setting a specific core count.