### PR TITLE
Async dbus interface

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::dbus::gpu::get_gpus;
 mod constants;
 mod performance;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> Result<(), Box<dyn Error>> {
     SimpleLogger::new().init().unwrap();
     log::info!("Starting PowerStation");

--- a/src/performance/gpu/amd/amdgpu.rs
+++ b/src/performance/gpu/amd/amdgpu.rs
@@ -1,14 +1,15 @@
 use std::{
     fs::{self, OpenOptions},
     io::Write,
-    sync::{
-        Arc, Mutex
-    }
+    sync::Arc
 };
+
+use tokio::sync::Mutex;
 
 use crate::constants::GPU_PATH;
 use crate::performance::gpu::interface::GPUIface;
-use crate::performance::gpu::{amd, tdp::TDPDevice};
+use crate::performance::gpu::amd;
+use crate::performance::gpu::dbus::devices::TDPDevices;
 use crate::performance::gpu::interface::{GPUError, GPUResult};
 
 #[derive(Debug, Clone)]
@@ -36,15 +37,17 @@ impl GPUIface for AMDGPU {
     }
 
     /// Returns the TDP DBus interface for this GPU
-    fn get_tdp_interface(&self) -> Option<Arc<Mutex<dyn TDPDevice>>> {
-        // TODO: if asusd is present, or asus-wmi is present this is where it is bound to the GPU
+    fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>> {
+        // if asusd is present, or asus-wmi is present this is where it is bound to the GPU
         match self.class.as_str() {
             "integrated" => Some(
                 Arc::new(
                     Mutex::new(
-                        amd::tdp::TDP::new(
-                            self.path.clone(),
-                            self.device_id.clone()
+                        TDPDevices::AMD(
+                            amd::tdp::TDP::new(
+                                self.path.clone(),
+                                self.device_id.clone()
+                            )
                         )
                     )
                 )

--- a/src/performance/gpu/amd/asus.rs
+++ b/src/performance/gpu/amd/asus.rs
@@ -23,7 +23,7 @@ pub struct ASUS {
 impl ASUS {
 
     /// test if we are in an asus system with asus-wmi loaded
-    pub fn new() -> Option<Self> {
+    pub async fn new() -> Option<Self> {
         match RogPlatform::new() {
             Ok(platform) => {
                 log::info!("Module asus-wmi WAS found");

--- a/src/performance/gpu/amd/asus.rs
+++ b/src/performance/gpu/amd/asus.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+use udev::{Enumerator, Device};
+
+use crate::performance::gpu::tdp::{TDPDevice, TDPResult, TDPError};
+use crate::performance::gpu::dbus::devices::TDPDevices;
+
+use zbus::{Connection, Result};
+
+use rog_dbus::RogDbusClientBlocking;
+use rog_dbus::DbusProxies;
+use rog_platform::{platform::RogPlatform, error::PlatformError};
+use rog_platform::platform::{GpuMode, Properties, ThrottlePolicy};
+use rog_profiles::error::ProfileError;
+
+use std::sync::Mutex;
+
+/// Implementation of asusd with a fallback to asus-wmi sysfs
+/// See https://www.kernel.org/doc/html/v6.8-rc4/admin-guide/abi-testing.html#abi-sys-devices-platform-platform-ppt-apu-sppt
+pub struct ASUS {
+    platform: Arc<Mutex<RogPlatform>>,
+}
+
+impl ASUS {
+
+    /// test if we are in an asus system with asus-wmi loaded
+    pub fn new() -> Option<Self> {
+        match RogPlatform::new() {
+            Ok(platform) => {
+                log::info!("Module asus-wmi WAS found");
+                Some(Self {
+                    platform: Arc::new(Mutex::new(platform))
+                })
+            },
+            Err(err) => {
+                log::info!("Module asus-wmi not found: {}", err);
+                None
+            }
+        }
+    }
+
+}
+
+impl TDPDevice for ASUS {
+    async fn tdp(&self) -> TDPResult<f64> {
+        match RogDbusClientBlocking::new() {
+            Ok((dbus, _)) => {
+                let supported_properties = dbus.proxies().platform().supported_properties().unwrap();
+                let supported_interfaces = dbus.proxies().platform().supported_interfaces().unwrap();
+
+                match dbus.proxies().platform().ppt_apu_sppt() {
+                    Ok(result) => {
+                        log::info!("Initial ppt_apu_sppt: {}", result);
+                        Ok(result as f64)
+                    },
+                    Err(err) => {
+                        log::warn!("Error fetching ppt_apu_sppt: {}", err);
+                        Err(TDPError::FailedOperation(format!("")))
+                    }
+                }
+            },
+            Err(err) => {
+                log::warn!("Unable to use asusd to read tdp, asus-wmi interface will be used");
+                Err(TDPError::FailedOperation(format!("")))
+            }
+        }
+    }
+
+    async fn set_tdp(&mut self, value: f64) -> TDPResult<()> {
+        todo!()
+    }
+
+    async fn boost(&self) -> TDPResult<f64> {
+        todo!()
+    }
+
+    async fn set_boost(&mut self, value: f64) -> TDPResult<()> {
+        todo!()
+    }
+
+    async fn thermal_throttle_limit_c(&self) -> TDPResult<f64> {
+        todo!()
+    }
+
+    async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()> {
+        todo!()
+    }
+
+    async fn power_profile(&self) -> TDPResult<String> {
+        todo!()
+    }
+
+    async fn set_power_profile(&mut self, profile: String) -> TDPResult<()> {
+        todo!()
+    }
+}

--- a/src/performance/gpu/amd/tdp.rs
+++ b/src/performance/gpu/amd/tdp.rs
@@ -221,8 +221,7 @@ impl TDP {
 }
 
 impl TDPDevice for TDP {
-
-    fn tdp(&self) -> TDPResult<f64> {
+    async fn tdp(&self) -> TDPResult<f64> {
         // Get the current stapm limit from ryzenadj
         match TDP::get_stapm_limit(&self) {
             Ok(result) => Ok(result.into()),
@@ -230,13 +229,12 @@ impl TDPDevice for TDP {
         }
     }
 
-    fn set_tdp(&mut self, value: f64) -> TDPResult<()> {
+    async fn set_tdp(&mut self, value: f64) -> TDPResult<()> {
         log::debug!("Setting TDP to: {}", value);
         if value < 1.0 {
             log::warn!("Cowardly refusing to set TDP less than 1W");
             return Err(TDPError::InvalidArgument(format!("Cowardly refusing to set TDP less than 1W: provided {}W", value)));
         }
-
 
         // Get the current boost value before updating the STAPM limit. We will
         // use this value to also adjust the Fast PPT Limit.
@@ -270,7 +268,7 @@ impl TDPDevice for TDP {
         Ok(())
     }
 
-    fn boost(&self) -> TDPResult<f64> {
+    async fn boost(&self) -> TDPResult<f64> {
         let fast_ppt_limit =
             TDP::get_ppt_limit_fast(&self).map_err(|err| TDPError::FailedOperation(String::from(err)))?;
         let fast_ppt_limit = fast_ppt_limit as f64;
@@ -283,7 +281,7 @@ impl TDPDevice for TDP {
         Ok(boost)
     }
 
-    fn set_boost(&mut self, value: f64) -> TDPResult<()> {
+    async fn set_boost(&mut self, value: f64) -> TDPResult<()> {
         log::debug!("Setting boost to: {}", value);
         if value < 0.0 {
             log::warn!("Cowardly refusing to set TDP Boost less than 0W");
@@ -301,22 +299,22 @@ impl TDPDevice for TDP {
         Ok(())
     }
 
-    fn thermal_throttle_limit_c(&self) -> TDPResult<f64> {
+    async fn thermal_throttle_limit_c(&self) -> TDPResult<f64> {
         let limit = TDP::get_thm_limit(&self).map_err(|err| TDPError::FailedOperation(err.to_string()))?;
         Ok(limit.into())
     }
 
-    fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()> {
+    async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()> {
         log::debug!("Setting thermal throttle limit to: {}", limit);
         let limit = limit as u32;
         TDP::set_thm_limit(self, limit).map_err(|err| TDPError::FailedOperation(err.to_string()))
     }
 
-    fn power_profile(&self) -> TDPResult<String> {
+    async fn power_profile(&self) -> TDPResult<String> {
         Ok(self.profile.clone())
     }
 
-    fn set_power_profile(&mut self, profile: String) -> TDPResult<()> {
+    async fn set_power_profile(&mut self, profile: String) -> TDPResult<()> {
         log::debug!("Setting power profile to: {}", profile);
         TDP::set_power_profile(&self, profile.clone())
             .map_err(|err| TDPError::FailedOperation(err.to_string()))?;

--- a/src/performance/gpu/dbus/devices.rs
+++ b/src/performance/gpu/dbus/devices.rs
@@ -1,0 +1,74 @@
+use crate::performance::gpu::tdp::{TDPDevice, TDPResult};
+
+pub enum TDPDevices {
+    //ASUS(crate::performance::gpu::amd::asus::ASUS),
+    AMD(crate::performance::gpu::amd::tdp::TDP),
+    INTEL(crate::performance::gpu::intel::tdp::TDP)
+}
+
+impl TDPDevices {
+    pub async fn tdp(&self) -> TDPResult<f64> {
+        match self {
+            //Self::ASUS(dev) => dev.tdp().await,
+            Self::AMD(dev) => dev.tdp().await,
+            Self::INTEL(dev) => dev.tdp().await,
+        }
+    }
+
+    pub async fn set_tdp(&mut self, value: f64) -> TDPResult<()> {
+        match self {
+            //Self::ASUS(dev) => dev.set_tdp(value).await,
+            Self::AMD(dev) => dev.set_tdp(value).await,
+            Self::INTEL(dev) => dev.set_tdp(value).await,
+        }
+    }
+
+    pub async fn boost(&self) -> TDPResult<f64> {
+        match self {
+            //Self::ASUS(dev) => dev.boost().await,
+            Self::AMD(dev) => dev.boost().await,
+            Self::INTEL(dev) => dev.boost().await,
+        }
+    }
+
+    pub async fn set_boost(&mut self, value: f64) -> TDPResult<()> {
+        match self {
+            //Self::ASUS(dev) => dev.set_boost(value).await,
+            Self::AMD(dev) => dev.set_boost(value).await,
+            Self::INTEL(dev) => dev.set_boost(value).await,
+        }
+    }
+
+    pub async fn thermal_throttle_limit_c(&self) -> TDPResult<f64> {
+        match self {
+            //Self::ASUS(dev) => dev.thermal_throttle_limit_c().await,
+            Self::AMD(dev) => dev.thermal_throttle_limit_c().await,
+            Self::INTEL(dev) => dev.thermal_throttle_limit_c().await,
+        }
+    }
+
+    pub async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()> {
+        match self {
+            //Self::ASUS(dev) => dev.set_thermal_throttle_limit_c(limit).await,
+            Self::AMD(dev) => dev.set_thermal_throttle_limit_c(limit).await,
+            Self::INTEL(dev) => dev.set_thermal_throttle_limit_c(limit).await,
+        }
+    }
+
+    pub async fn power_profile(&self) -> TDPResult<String> {
+        match self {
+            //Self::ASUS(dev) => dev.power_profile().await,
+            Self::AMD(dev) => dev.power_profile().await,
+            Self::INTEL(dev) => dev.power_profile().await,
+        }
+    }
+
+    pub async fn set_power_profile(&mut self, profile: String) -> TDPResult<()> {
+        match self {
+            //Self::ASUS(dev) => dev.set_power_profile(profile).await,
+            Self::AMD(dev) => dev.set_power_profile(profile).await,
+            Self::INTEL(dev) => dev.set_power_profile(profile).await,
+        }
+    }
+
+}

--- a/src/performance/gpu/dbus/devices.rs
+++ b/src/performance/gpu/dbus/devices.rs
@@ -1,4 +1,9 @@
-use crate::performance::gpu::tdp::{TDPDevice, TDPResult};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::performance::gpu::{interface::GPUDevice, tdp::{TDPDevice, TDPResult}};
+use crate::performance::gpu::interface::GPUResult;
 
 pub enum TDPDevices {
     //ASUS(crate::performance::gpu::amd::asus::ASUS),
@@ -68,6 +73,168 @@ impl TDPDevices {
             //Self::ASUS(dev) => dev.set_power_profile(profile).await,
             Self::AMD(dev) => dev.set_power_profile(profile).await,
             Self::INTEL(dev) => dev.set_power_profile(profile).await,
+        }
+    }
+
+}
+
+pub enum GPUDevices {
+    AMDGPU(crate::performance::gpu::amd::amdgpu::AMDGPU),
+    INTELGPU(crate::performance::gpu::intel::intelgpu::IntelGPU),
+}
+
+impl GPUDevices {
+    pub async fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>> {
+        match self {
+            Self::AMDGPU(dev) => dev.get_tdp_interface().await,
+            Self::INTELGPU(dev) => dev.get_tdp_interface().await,
+        }
+    }
+
+    pub async fn get_gpu_path(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.get_gpu_path().await,
+            Self::INTELGPU(dev) => dev.get_gpu_path().await,
+        }
+    }
+    
+    pub async fn name(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.name().await,
+            Self::INTELGPU(dev) => dev.name().await,
+        }
+    }
+
+    pub async fn path(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.path().await,
+            Self::INTELGPU(dev) => dev.path().await,
+        }
+    }
+
+    pub async fn class(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.class().await,
+            Self::INTELGPU(dev) => dev.class().await,
+        }
+    }
+
+    pub async fn class_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.class_id().await,
+            Self::INTELGPU(dev) => dev.class_id().await,
+        }
+    }
+
+    pub async fn vendor(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.vendor().await,
+            Self::INTELGPU(dev) => dev.vendor().await,
+        }
+    }
+
+    pub async fn vendor_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.vendor_id().await,
+            Self::INTELGPU(dev) => dev.vendor_id().await,
+        }
+    }
+
+    pub async fn device(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.device().await,
+            Self::INTELGPU(dev) => dev.device().await,
+        }
+    }
+
+    pub async fn device_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.device_id().await,
+            Self::INTELGPU(dev) => dev.device_id().await,
+        }
+    }
+
+    pub async fn subdevice(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.subdevice().await,
+            Self::INTELGPU(dev) => dev.subdevice().await,
+        }
+    }
+
+    pub async fn subdevice_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.subdevice_id().await,
+            Self::INTELGPU(dev) => dev.subdevice_id().await,
+        }
+    }
+
+    pub async fn subvendor_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.subvendor_id().await,
+            Self::INTELGPU(dev) => dev.subvendor_id().await,
+        }
+    }
+
+    pub async fn revision_id(&self) -> String {
+        match self {
+            Self::AMDGPU(dev) => dev.revision_id().await,
+            Self::INTELGPU(dev) => dev.revision_id().await,
+        }
+    }
+
+    pub async fn clock_limit_mhz_min(&self) -> GPUResult<f64> {
+        match self {
+            Self::AMDGPU(dev) => dev.clock_limit_mhz_min().await,
+            Self::INTELGPU(dev) => dev.clock_limit_mhz_min().await,
+        }
+    }
+
+    pub async fn clock_limit_mhz_max(&self) -> GPUResult<f64> {
+        match self {
+            Self::AMDGPU(dev) => dev.clock_limit_mhz_max().await,
+            Self::INTELGPU(dev) => dev.clock_limit_mhz_max().await,
+        }
+    }
+
+    pub async fn clock_value_mhz_min(&self) -> GPUResult<f64> {
+        match self {
+            Self::AMDGPU(dev) => dev.clock_value_mhz_min().await,
+            Self::INTELGPU(dev) => dev.clock_value_mhz_min().await,
+        }
+    }
+
+    pub async fn set_clock_value_mhz_min(&mut self, value: f64) -> GPUResult<()> {
+        match self {
+            Self::AMDGPU(dev) => dev.set_clock_value_mhz_min(value).await,
+            Self::INTELGPU(dev) => dev.set_clock_value_mhz_min(value).await,
+        }
+    }
+
+    pub async fn clock_value_mhz_max(&self) -> GPUResult<f64> {
+        match self {
+            Self::AMDGPU(dev) => dev.clock_value_mhz_max().await,
+            Self::INTELGPU(dev) => dev.clock_value_mhz_max().await,
+        }
+    }
+
+    pub async fn set_clock_value_mhz_max(&mut self, value: f64) -> GPUResult<()> {
+        match self {
+            Self::AMDGPU(dev) => dev.set_clock_value_mhz_max(value).await,
+            Self::INTELGPU(dev) => dev.set_clock_value_mhz_max(value).await,
+        }
+    }
+
+    pub async fn manual_clock(&self) -> GPUResult<bool> {
+        match self {
+            Self::AMDGPU(dev) => dev.manual_clock().await,
+            Self::INTELGPU(dev) => dev.manual_clock().await,
+        }
+    }
+
+    pub async fn set_manual_clock(&mut self, enabled: bool) -> GPUResult<()> {
+        match self {
+            Self::AMDGPU(dev) => dev.set_manual_clock(enabled).await,
+            Self::INTELGPU(dev) => dev.set_manual_clock(enabled).await,
         }
     }
 

--- a/src/performance/gpu/dbus/gpu.rs
+++ b/src/performance/gpu/dbus/gpu.rs
@@ -1,9 +1,11 @@
 use std::fs::{self, File};
 use std::io::{prelude::*, BufReader};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use zbus::fdo;
 use zbus::zvariant::ObjectPath;
 use zbus_macros::dbus_interface;
+
+use tokio::sync::Mutex;
 
 use crate::performance::gpu::interface::{GPUError, GPUIface};
 use crate::performance::gpu::dbus::tdp::GPUTDPDBusIface;
@@ -40,16 +42,16 @@ impl GPUDBusInterface {
         }
     }
 
-    pub fn gpu_path(&self) -> String {
-        self.gpu_obj.lock().unwrap().get_gpu_path()
+    pub async fn gpu_path(&self) -> String {
+        self.gpu_obj.lock().await.get_gpu_path()
     }
 
-    pub fn set_connector_paths(&mut self, connector_paths: Vec<String>) {
+    pub async fn set_connector_paths(&mut self, connector_paths: Vec<String>) {
         self.connector_paths = connector_paths
     }
 
-    pub fn get_tdp_interface(&self) -> Option<GPUTDPDBusIface> {
-        match self.gpu_obj.lock().unwrap().get_tdp_interface() {
+    pub async fn get_tdp_interface(&self) -> Option<GPUTDPDBusIface> {
+        match self.gpu_obj.lock().await.get_tdp_interface() {
             Some(tdp) => Some(GPUTDPDBusIface::new(tdp)),
             None => None
         }
@@ -70,103 +72,103 @@ impl GPUDBusInterface {
     }
 
     #[dbus_interface(property)]
-    pub fn name(&self) -> String {
-        self.gpu_obj.lock().unwrap().name()
+    pub async fn name(&self) -> String {
+        self.gpu_obj.lock().await.name()
     }
 
     #[dbus_interface(property)]
-    fn path(&self) -> String {
-        self.gpu_obj.lock().unwrap().path()
+    async fn path(&self) -> String {
+        self.gpu_obj.lock().await.path()
     }
 
     #[dbus_interface(property)]
-    fn class(&self) -> String {
-        self.gpu_obj.lock().unwrap().class()
+    async fn class(&self) -> String {
+        self.gpu_obj.lock().await.class()
     }
 
     #[dbus_interface(property)]
-    fn class_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().class_id()
+    async fn class_id(&self) -> String {
+        self.gpu_obj.lock().await.class_id()
     }
 
     #[dbus_interface(property)]
-    fn vendor(&self) -> String {
-        self.gpu_obj.lock().unwrap().vendor()
+    async fn vendor(&self) -> String {
+        self.gpu_obj.lock().await.vendor()
     }
 
     #[dbus_interface(property)]
-    fn vendor_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().vendor_id()
+    async fn vendor_id(&self) -> String {
+        self.gpu_obj.lock().await.vendor_id()
     }
 
     #[dbus_interface(property)]
-    fn device(&self) -> String {
-        self.gpu_obj.lock().unwrap().device()
+    async fn device(&self) -> String {
+        self.gpu_obj.lock().await.device()
     }
 
     #[dbus_interface(property)]
-    fn device_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().device_id()
+    async fn device_id(&self) -> String {
+        self.gpu_obj.lock().await.device_id()
     }
 
     #[dbus_interface(property)]
-    fn subdevice(&self) -> String {
-        self.gpu_obj.lock().unwrap().subdevice()
+    async fn subdevice(&self) -> String {
+        self.gpu_obj.lock().await.subdevice()
     }
 
     #[dbus_interface(property)]
-    fn subdevice_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().subdevice_id()
+    async fn subdevice_id(&self) -> String {
+        self.gpu_obj.lock().await.subdevice_id()
     }
 
     #[dbus_interface(property)]
-    fn subvendor_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().subvendor_id()
+    async fn subvendor_id(&self) -> String {
+        self.gpu_obj.lock().await.subvendor_id()
     }
 
     #[dbus_interface(property)]
-    fn revision_id(&self) -> String {
-        self.gpu_obj.lock().unwrap().revision_id()
+    async fn revision_id(&self) -> String {
+        self.gpu_obj.lock().await.revision_id()
     }
 
     #[dbus_interface(property)]
-    fn clock_limit_mhz_min(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().unwrap().clock_limit_mhz_min().map_err(|err| err.into())
+    async fn clock_limit_mhz_min(&self) -> fdo::Result<f64> {
+        self.gpu_obj.lock().await.clock_limit_mhz_min().map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn clock_limit_mhz_max(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().unwrap().clock_limit_mhz_max().map_err(|err| err.into())
+    async fn clock_limit_mhz_max(&self) -> fdo::Result<f64> {
+        self.gpu_obj.lock().await.clock_limit_mhz_max().map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn clock_value_mhz_min(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().unwrap().clock_value_mhz_min().map_err(|err| err.into())
+    async fn clock_value_mhz_min(&self) -> fdo::Result<f64> {
+        self.gpu_obj.lock().await.clock_value_mhz_min().map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn set_clock_value_mhz_min(&mut self, value: f64) -> fdo::Result<()> {
-        self.gpu_obj.lock().unwrap().set_clock_value_mhz_min(value).map_err(|err| err.into())
+    async fn set_clock_value_mhz_min(&mut self, value: f64) -> fdo::Result<()> {
+        self.gpu_obj.lock().await.set_clock_value_mhz_min(value).map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn clock_value_mhz_max(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().unwrap().clock_value_mhz_max().map_err(|err| err.into())
+    async fn clock_value_mhz_max(&self) -> fdo::Result<f64> {
+        self.gpu_obj.lock().await.clock_value_mhz_max().map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn set_clock_value_mhz_max(&mut self, value: f64) -> fdo::Result<()> {
-        self.gpu_obj.lock().unwrap().set_clock_value_mhz_max(value).map_err(|err| err.into())
+    async fn set_clock_value_mhz_max(&mut self, value: f64) -> fdo::Result<()> {
+        self.gpu_obj.lock().await.set_clock_value_mhz_max(value)/*.await*/.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn manual_clock(&self) -> fdo::Result<bool> {
-        self.gpu_obj.lock().unwrap().manual_clock().map_err(|err| err.into())
+    async fn manual_clock(&self) -> fdo::Result<bool> {
+        self.gpu_obj.lock().await.manual_clock()/*.await*/.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
-    fn set_manual_clock(&mut self, enabled: bool) -> fdo::Result<()> {
-        self.gpu_obj.lock().unwrap().set_manual_clock(enabled).map_err(|err| err.into())
+    async fn set_manual_clock(&mut self, enabled: bool) -> fdo::Result<()> {
+        self.gpu_obj.lock().await.set_manual_clock(enabled)/*.await*/.map_err(|err| err.into())
     }
 }
 
@@ -187,7 +189,7 @@ impl GPUBus {
 #[dbus_interface(name = "org.shadowblip.GPU")]
 impl GPUBus {
     /// Returns a list of DBus paths to all GPU cards
-    pub fn enumerate_cards(&self) -> fdo::Result<Vec<ObjectPath>> {
+    pub async fn enumerate_cards(&self) -> fdo::Result<Vec<ObjectPath>> {
         let mut paths: Vec<ObjectPath> = Vec::new();
 
         for item in &self.gpu_object_paths {
@@ -200,7 +202,7 @@ impl GPUBus {
 }
 
 /// Returns a list of all detected gpu devices
-pub fn get_gpus() -> Vec<GPUDBusInterface> {
+pub async fn get_gpus() -> Vec<GPUDBusInterface> {
     let mut gpus = vec![];
     let paths = fs::read_dir(DRM_PATH).unwrap();
     for path in paths {

--- a/src/performance/gpu/dbus/gpu.rs
+++ b/src/performance/gpu/dbus/gpu.rs
@@ -7,7 +7,8 @@ use zbus_macros::dbus_interface;
 
 use tokio::sync::Mutex;
 
-use crate::performance::gpu::interface::{GPUError, GPUIface};
+use crate::performance::gpu::interface::GPUError;
+use crate::performance::gpu::dbus::devices::GPUDevices;
 use crate::performance::gpu::dbus::tdp::GPUTDPDBusIface;
 use crate::performance::gpu::amd::amdgpu::AMDGPU;
 use crate::performance::gpu::connector::Connector;
@@ -31,11 +32,11 @@ impl Into<fdo::Error> for GPUError {
 #[derive(Clone)]
 pub struct GPUDBusInterface {
     connector_paths: Vec<String>,
-    gpu_obj: Arc<Mutex<dyn GPUIface>>
+    gpu_obj: Arc<Mutex<GPUDevices>>
 }
 
 impl GPUDBusInterface {
-    pub fn new(gpu: Arc<Mutex<dyn GPUIface>>) -> Self {
+    pub async fn new(gpu: Arc<Mutex<GPUDevices>>) -> Self {
         Self {
             gpu_obj: gpu,
             connector_paths: vec![]
@@ -43,7 +44,7 @@ impl GPUDBusInterface {
     }
 
     pub async fn gpu_path(&self) -> String {
-        self.gpu_obj.lock().await.get_gpu_path()
+        self.gpu_obj.lock().await.get_gpu_path().await
     }
 
     pub async fn set_connector_paths(&mut self, connector_paths: Vec<String>) {
@@ -51,7 +52,7 @@ impl GPUDBusInterface {
     }
 
     pub async fn get_tdp_interface(&self) -> Option<GPUTDPDBusIface> {
-        match self.gpu_obj.lock().await.get_tdp_interface() {
+        match self.gpu_obj.lock().await.get_tdp_interface().await {
             Some(tdp) => Some(GPUTDPDBusIface::new(tdp)),
             None => None
         }
@@ -73,102 +74,102 @@ impl GPUDBusInterface {
 
     #[dbus_interface(property)]
     pub async fn name(&self) -> String {
-        self.gpu_obj.lock().await.name()
+        self.gpu_obj.lock().await.name().await
     }
 
     #[dbus_interface(property)]
     async fn path(&self) -> String {
-        self.gpu_obj.lock().await.path()
+        self.gpu_obj.lock().await.path().await
     }
 
     #[dbus_interface(property)]
     async fn class(&self) -> String {
-        self.gpu_obj.lock().await.class()
+        self.gpu_obj.lock().await.class().await
     }
 
     #[dbus_interface(property)]
     async fn class_id(&self) -> String {
-        self.gpu_obj.lock().await.class_id()
+        self.gpu_obj.lock().await.class_id().await
     }
 
     #[dbus_interface(property)]
     async fn vendor(&self) -> String {
-        self.gpu_obj.lock().await.vendor()
+        self.gpu_obj.lock().await.vendor().await
     }
 
     #[dbus_interface(property)]
     async fn vendor_id(&self) -> String {
-        self.gpu_obj.lock().await.vendor_id()
+        self.gpu_obj.lock().await.vendor_id().await
     }
 
     #[dbus_interface(property)]
     async fn device(&self) -> String {
-        self.gpu_obj.lock().await.device()
+        self.gpu_obj.lock().await.device().await
     }
 
     #[dbus_interface(property)]
     async fn device_id(&self) -> String {
-        self.gpu_obj.lock().await.device_id()
+        self.gpu_obj.lock().await.device_id().await
     }
 
     #[dbus_interface(property)]
     async fn subdevice(&self) -> String {
-        self.gpu_obj.lock().await.subdevice()
+        self.gpu_obj.lock().await.subdevice().await
     }
 
     #[dbus_interface(property)]
     async fn subdevice_id(&self) -> String {
-        self.gpu_obj.lock().await.subdevice_id()
+        self.gpu_obj.lock().await.subdevice_id().await
     }
 
     #[dbus_interface(property)]
     async fn subvendor_id(&self) -> String {
-        self.gpu_obj.lock().await.subvendor_id()
+        self.gpu_obj.lock().await.subvendor_id().await
     }
 
     #[dbus_interface(property)]
     async fn revision_id(&self) -> String {
-        self.gpu_obj.lock().await.revision_id()
+        self.gpu_obj.lock().await.revision_id().await
     }
 
     #[dbus_interface(property)]
     async fn clock_limit_mhz_min(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().await.clock_limit_mhz_min().map_err(|err| err.into())
+        self.gpu_obj.lock().await.clock_limit_mhz_min().await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn clock_limit_mhz_max(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().await.clock_limit_mhz_max().map_err(|err| err.into())
+        self.gpu_obj.lock().await.clock_limit_mhz_max().await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn clock_value_mhz_min(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().await.clock_value_mhz_min().map_err(|err| err.into())
+        self.gpu_obj.lock().await.clock_value_mhz_min().await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn set_clock_value_mhz_min(&mut self, value: f64) -> fdo::Result<()> {
-        self.gpu_obj.lock().await.set_clock_value_mhz_min(value).map_err(|err| err.into())
+        self.gpu_obj.lock().await.set_clock_value_mhz_min(value).await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn clock_value_mhz_max(&self) -> fdo::Result<f64> {
-        self.gpu_obj.lock().await.clock_value_mhz_max().map_err(|err| err.into())
+        self.gpu_obj.lock().await.clock_value_mhz_max().await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn set_clock_value_mhz_max(&mut self, value: f64) -> fdo::Result<()> {
-        self.gpu_obj.lock().await.set_clock_value_mhz_max(value)/*.await*/.map_err(|err| err.into())
+        self.gpu_obj.lock().await.set_clock_value_mhz_max(value).await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn manual_clock(&self) -> fdo::Result<bool> {
-        self.gpu_obj.lock().await.manual_clock()/*.await*/.map_err(|err| err.into())
+        self.gpu_obj.lock().await.manual_clock().await.map_err(|err| err.into())
     }
 
     #[dbus_interface(property)]
     async fn set_manual_clock(&mut self, enabled: bool) -> fdo::Result<()> {
-        self.gpu_obj.lock().await.set_manual_clock(enabled)/*.await*/.map_err(|err| err.into())
+        self.gpu_obj.lock().await.set_manual_clock(enabled).await.map_err(|err| err.into())
     }
 }
 
@@ -218,19 +219,22 @@ pub async fn get_gpus() -> Vec<GPUDBusInterface> {
         }
 
         log::info!("Discovered gpu: {}", file_path);
-        let gpu = get_gpu(file_path);
-        if gpu.is_err() {
-            continue;
+        match get_gpu(file_path).await {
+            Ok(gpu) => {
+                gpus.push(gpu)
+            },
+            Err(err) => {
+                log::error!("Error in get_gpu: {}", err);
+                continue;
+            }
         }
-
-        gpus.push(gpu.unwrap());
     }
 
     return gpus;
 }
 
 /// Returns the GPU instance for the given path in /sys/class/drm
-pub fn get_gpu(path: String) -> Result<GPUDBusInterface, std::io::Error> {
+pub async fn get_gpu(path: String) -> Result<GPUDBusInterface, std::io::Error> {
     let filename = path.split("/").last().unwrap();
     let file_prefix = format!("{0}/{1}", path, "device");
     let class_id = fs::read_to_string(format!("{0}/{1}", file_prefix, "class"))?
@@ -345,49 +349,53 @@ pub fn get_gpu(path: String) -> Result<GPUDBusInterface, std::io::Error> {
             GPUDBusInterface::new(
                 Arc::new(
                     Mutex::new(
-                        AMDGPU {
-                            name: filename.to_string(),
-                            path: path.clone(),
-                            class: class.to_string(),
-                            class_id,
-                            vendor: "AMD".to_string(),
-                            vendor_id,
-                            device: device.unwrap_or("".to_string()),
-                            device_id,
-                            device_type: "".to_string(),
-                            subdevice: subdevice.unwrap_or("".to_string()),
-                            subdevice_id,
-                            subvendor_id,
-                            revision_id,
-                        }
+                        GPUDevices::AMDGPU(
+                            AMDGPU {
+                                name: filename.to_string(),
+                                path: path.clone(),
+                                class: class.to_string(),
+                                class_id,
+                                vendor: "AMD".to_string(),
+                                vendor_id,
+                                device: device.unwrap_or("".to_string()),
+                                device_id,
+                                device_type: "".to_string(),
+                                subdevice: subdevice.unwrap_or("".to_string()),
+                                subdevice_id,
+                                subvendor_id,
+                                revision_id,
+                            }
+                        )
                     )
                 )
-            )
+            ).await
         ),
         // Intel Implementation
         "Intel" | "GenuineIntel" | "Intel Corporation" => Ok(
             GPUDBusInterface::new(
                 Arc::new(
                     Mutex::new(
-                        IntelGPU {
-                            name: filename.to_string(),
-                            path: path.clone(),
-                            class: class.to_string(),
-                            class_id,
-                            vendor: "Intel".to_string(),
-                            vendor_id,
-                            device: device.unwrap_or("".to_string()),
-                            device_id,
-                            device_type: "".to_string(),
-                            subdevice: subdevice.unwrap_or("".to_string()),
-                            subdevice_id,
-                            subvendor_id,
-                            revision_id,
-                            manual_clock: true,
-                        }
+                        GPUDevices::INTELGPU(
+                            IntelGPU {
+                                name: filename.to_string(),
+                                path: path.clone(),
+                                class: class.to_string(),
+                                class_id,
+                                vendor: "Intel".to_string(),
+                                vendor_id,
+                                device: device.unwrap_or("".to_string()),
+                                device_id,
+                                device_type: "".to_string(),
+                                subdevice: subdevice.unwrap_or("".to_string()),
+                                subdevice_id,
+                                subvendor_id,
+                                revision_id,
+                                manual_clock: true,
+                            }
+                        )
                     )
                 )
-            )
+            ).await
         ),
         _ => {
             Err(std::io::Error::new(

--- a/src/performance/gpu/dbus/mod.rs
+++ b/src/performance/gpu/dbus/mod.rs
@@ -1,2 +1,3 @@
 pub mod tdp;
 pub mod gpu;
+pub mod devices;

--- a/src/performance/gpu/dbus/tdp.rs
+++ b/src/performance/gpu/dbus/tdp.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
-use std::sync::Mutex;
-use zbus::fdo::Error;
 use zbus::fdo;
 use zbus_macros::dbus_interface;
 
+use tokio::sync::Mutex;
+
 use crate::performance::gpu::tdp::TDPError;
-use crate::performance::gpu::tdp::{TDPDevice, TDPResult};
+use crate::performance::gpu::tdp::TDPResult;
+use crate::performance::gpu::dbus::devices::TDPDevices;
 
 pub struct GPUTDPDBusIface {
-    dev: Arc<Mutex<dyn TDPDevice>>
+    dev: Arc<Mutex<TDPDevices>>
 }
 
 impl Into<fdo::Error> for TDPError {
@@ -23,7 +24,7 @@ impl Into<fdo::Error> for TDPError {
 }
 
 impl GPUTDPDBusIface {
-    pub fn new(dev: Arc<Mutex<dyn TDPDevice>>) -> GPUTDPDBusIface {
+    pub fn new(dev: Arc<Mutex<TDPDevices>>) -> GPUTDPDBusIface {
         GPUTDPDBusIface {
             dev
         }
@@ -35,125 +36,69 @@ impl GPUTDPDBusIface {
 
     /// Get the currently set TDP value
     #[dbus_interface(property, name = "TDP")]
-    fn tdp(&self) -> fdo::Result<f64> {
-        match self.dev.lock() {
-            Ok(lck) => {
-                match lck.tdp() {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn tdp(&self) -> fdo::Result<f64> {
+        match self.dev.lock().await.tdp().await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     /// Sets the given TDP value
     #[dbus_interface(property, name = "TDP")]
-    fn set_tdp(&mut self, value: f64) -> fdo::Result<()> {
-        match self.dev.lock() {
-            Ok(mut lck) => {
-                match lck.set_tdp(value) {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn set_tdp(&mut self, value: f64) -> fdo::Result<()> {
+        match self.dev.lock().await.set_tdp(value).await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     /// The TDP boost for AMD is the total difference between the Fast PPT Limit
     /// and the STAPM limit.
     #[dbus_interface(property)]
-    fn boost(&self) -> fdo::Result<f64> {
-        match self.dev.lock() {
-            Ok(lck) => {
-                match lck.boost() {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn boost(&self) -> fdo::Result<f64> {
+        match self.dev.lock().await.boost().await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     #[dbus_interface(property)]
-    fn set_boost(&mut self, value: f64) -> fdo::Result<()> {
-        match self.dev.lock() {
-            Ok(mut lck) => {
-                match lck.set_boost(value) {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn set_boost(&mut self, value: f64) -> fdo::Result<()> {
+        match self.dev.lock().await.set_boost(value).await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     #[dbus_interface(property)]
-    fn thermal_throttle_limit_c(&self) -> fdo::Result<f64> {
-        match self.dev.lock() {
-            Ok(lck) => {
-                match lck.thermal_throttle_limit_c() {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn thermal_throttle_limit_c(&self) -> fdo::Result<f64> {
+        match self.dev.lock().await.thermal_throttle_limit_c().await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     #[dbus_interface(property)]
-    fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> fdo::Result<()> {
-        match self.dev.lock() {
-            Ok(mut lck) => {
-                match lck.set_thermal_throttle_limit_c(limit) {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> fdo::Result<()> {
+        match self.dev.lock().await.set_thermal_throttle_limit_c(limit).await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     #[dbus_interface(property)]
-    fn power_profile(&self) -> fdo::Result<String> {
-        match self.dev.lock() {
-            Ok(lck) => {
-                match lck.power_profile() {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn power_profile(&self) -> fdo::Result<String> {
+        match self.dev.lock().await.power_profile().await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 
     #[dbus_interface(property)]
-    fn set_power_profile(&mut self, profile: String) -> fdo::Result<()> {
-        match self.dev.lock() {
-            Ok(mut lck) => {
-                match lck.set_power_profile(profile) {
-                    TDPResult::Ok(result) => Ok(result),
-                    TDPResult::Err(err) => Err(err.into())
-                }
-            },
-            Err(err) => {
-                Err(Error::Failed(format!("Unable to lock mutex: {}", err)))
-            }
+    async fn set_power_profile(&mut self, profile: String) -> fdo::Result<()> {
+        match self.dev.lock().await.set_power_profile(profile).await {
+            TDPResult::Ok(result) => Ok(result),
+            TDPResult::Err(err) => Err(err.into())
         }
     }
 

--- a/src/performance/gpu/intel/intelgpu.rs
+++ b/src/performance/gpu/intel/intelgpu.rs
@@ -1,15 +1,16 @@
 use std::{
     fs::{self, OpenOptions},
     io::Write,
-    sync::{
-        Arc, Mutex
-    }
+    sync::Arc
 };
+
+use tokio::sync::Mutex;
 
 use crate::constants::PREFIX;
 use crate::performance::gpu::interface::GPUIface;
-use crate::performance::gpu::{intel, tdp::TDPDevice};
+use crate::performance::gpu::intel;
 use crate::performance::gpu::interface::{GPUError, GPUResult};
+use crate::performance::gpu::dbus::devices::TDPDevices;
 
 #[derive(Debug, Clone)]
 pub struct IntelGPU {
@@ -37,13 +38,15 @@ impl GPUIface for IntelGPU {
     }
 
     /// Returns the TDP DBus interface for this GPU
-    fn get_tdp_interface(&self) -> Option<Arc<Mutex<dyn TDPDevice>>> {
+    fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>> {
         match self.class.as_str() {
             "integrated" => Some(
                 Arc::new(
                     Mutex::new(
-                        intel::tdp::TDP::new(
-                            self.path.clone()
+                        TDPDevices::INTEL(
+                            intel::tdp::TDP::new(
+                                self.path.clone()
+                            )
                         )
                     )
                 )

--- a/src/performance/gpu/intel/intelgpu.rs
+++ b/src/performance/gpu/intel/intelgpu.rs
@@ -7,7 +7,7 @@ use std::{
 use tokio::sync::Mutex;
 
 use crate::constants::PREFIX;
-use crate::performance::gpu::interface::GPUIface;
+use crate::performance::gpu::interface::GPUDevice;
 use crate::performance::gpu::intel;
 use crate::performance::gpu::interface::{GPUError, GPUResult};
 use crate::performance::gpu::dbus::devices::TDPDevices;
@@ -31,14 +31,14 @@ pub struct IntelGPU {
 }
 
 
-impl GPUIface for IntelGPU {
+impl GPUDevice for IntelGPU {
     
-    fn get_gpu_path(&self) -> String {
-        format!("{0}/GPU/{1}", PREFIX, self.name())
+    async fn get_gpu_path(&self) -> String {
+        format!("{0}/GPU/{1}", PREFIX, self.name().await)
     }
 
     /// Returns the TDP DBus interface for this GPU
-    fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>> {
+    async fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>> {
         match self.class.as_str() {
             "integrated" => Some(
                 Arc::new(
@@ -55,56 +55,56 @@ impl GPUIface for IntelGPU {
         }
     }
 
-    fn name(&self) -> String {
+    async fn name(&self) -> String {
         self.name.clone()
     }
 
-    fn path(&self) -> String {
+    async fn path(&self) -> String {
         self.path.clone()
     }
 
-    fn class(&self) -> String {
+    async fn class(&self) -> String {
         self.class.clone()
     }
 
-    fn class_id(&self) -> String {
+    async fn class_id(&self) -> String {
         self.class_id.clone()
     }
 
-    fn vendor(&self) -> String {
+    async fn vendor(&self) -> String {
         self.vendor.clone()
     }
 
-    fn vendor_id(&self) -> String {
+    async fn vendor_id(&self) -> String {
         self.vendor_id.clone()
     }
 
-    fn device(&self) -> String {
+    async fn device(&self) -> String {
         self.device.clone()
     }
 
-    fn device_id(&self) -> String {
+    async fn device_id(&self) -> String {
         self.device_id.clone()
     }
 
-    fn subdevice(&self) -> String {
+    async fn subdevice(&self) -> String {
         self.subdevice.clone()
     }
 
-    fn subdevice_id(&self) -> String {
+    async fn subdevice_id(&self) -> String {
         self.subdevice_id.clone()
     }
 
-    fn subvendor_id(&self) -> String {
+    async fn subvendor_id(&self) -> String {
         self.subvendor_id.clone()
     }
 
-    fn revision_id(&self) -> String {
+    async fn revision_id(&self) -> String {
         self.revision_id.clone()
     }
 
-    fn clock_limit_mhz_min(&self) -> GPUResult<f64> {
-        let path = format!("{0}/{1}", self.path(), "gt_RPn_freq_mhz");
+    async fn clock_limit_mhz_min(&self) -> GPUResult<f64> {
+        let path = format!("{0}/{1}", self.path().await, "gt_RPn_freq_mhz");
         let result = fs::read_to_string(path);
         let limit = result
             .map_err(|err| GPUError::IOError(err.to_string()))?
@@ -115,8 +115,8 @@ impl GPUIface for IntelGPU {
         return Ok(limit);
     }
 
-    fn clock_limit_mhz_max(&self) -> GPUResult<f64> {
-        let path = format!("{0}/{1}", self.path(), "gt_RP0_freq_mhz");
+    async fn clock_limit_mhz_max(&self) -> GPUResult<f64> {
+        let path = format!("{0}/{1}", self.path().await, "gt_RP0_freq_mhz");
         let limit = fs::read_to_string(path)
             .map_err(|err| GPUError::IOError(err.to_string()))?
             .trim()
@@ -126,8 +126,8 @@ impl GPUIface for IntelGPU {
         return Ok(limit);
     }
 
-    fn clock_value_mhz_min(&self) -> GPUResult<f64> {
-        let path = format!("{0}/{1}", self.path(), "gt_min_freq_mhz");
+    async fn clock_value_mhz_min(&self) -> GPUResult<f64> {
+        let path = format!("{0}/{1}", self.path().await, "gt_min_freq_mhz");
         let result = fs::read_to_string(path);
         let value = result
             .map_err(|err| GPUError::IOError(err.to_string()))?
@@ -138,7 +138,7 @@ impl GPUIface for IntelGPU {
         return Ok(value);
     }
 
-    fn set_clock_value_mhz_min(&mut self, value: f64) -> GPUResult<()> {
+    async fn set_clock_value_mhz_min(&mut self, value: f64) -> GPUResult<()> {
         if value == 0.0 {
             return Err(GPUError::InvalidArgument(
                 "Cowardly refusing to set clock to 0MHz".to_string(),
@@ -146,7 +146,7 @@ impl GPUIface for IntelGPU {
         }
 
         // Open the sysfs file to write to
-        let path = format!("{0}/{1}", self.path(), "gt_min_freq_mhz");
+        let path = format!("{0}/{1}", self.path().await, "gt_min_freq_mhz");
         let file = OpenOptions::new().write(true).open(path);
 
         // Write the value
@@ -158,8 +158,8 @@ impl GPUIface for IntelGPU {
         return Ok(());
     }
 
-    fn clock_value_mhz_max(&self) -> GPUResult<f64> {
-        let path = format!("{0}/{1}", self.path(), "gt_max_freq_mhz");
+    async fn clock_value_mhz_max(&self) -> GPUResult<f64> {
+        let path = format!("{0}/{1}", self.path().await, "gt_max_freq_mhz");
         let result = fs::read_to_string(path);
         let value = result
             .map_err(|err| GPUError::IOError(err.to_string()))?
@@ -170,7 +170,7 @@ impl GPUIface for IntelGPU {
         return Ok(value);
     }
 
-    fn set_clock_value_mhz_max(&mut self, value: f64) -> GPUResult<()> {
+    async fn set_clock_value_mhz_max(&mut self, value: f64) -> GPUResult<()> {
         if value == 0.0 {
             return Err(GPUError::InvalidArgument(
                 "Cowardly refusing to set clock to 0MHz".to_string(),
@@ -178,7 +178,7 @@ impl GPUIface for IntelGPU {
         }
 
         // Open the sysfs file to write to
-        let path = format!("{0}/{1}", self.path(), "gt_max_freq_mhz");
+        let path = format!("{0}/{1}", self.path().await, "gt_max_freq_mhz");
         let file = OpenOptions::new().write(true).open(path);
 
         // Write the value
@@ -190,11 +190,11 @@ impl GPUIface for IntelGPU {
         return Ok(());
     }
 
-    fn manual_clock(&self) -> GPUResult<bool> {
+    async fn manual_clock(&self) -> GPUResult<bool> {
         return Ok(self.manual_clock.clone());
     }
 
-    fn set_manual_clock(&mut self, enabled: bool) -> GPUResult<()> {
+    async fn set_manual_clock(&mut self, enabled: bool) -> GPUResult<()> {
         self.manual_clock = enabled;
         return Ok(());
     }

--- a/src/performance/gpu/interface.rs
+++ b/src/performance/gpu/interface.rs
@@ -20,30 +20,29 @@ impl Into<String> for GPUError {
 pub type GPUResult<T> = Result<T, GPUError>;
 
 /// Represents the data contained in /sys/class/drm/cardX
-pub trait GPUIface: Send + Sync {
+pub trait GPUDevice: Send + Sync {
+    async fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>>;
 
-    fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>>;
-
-    fn get_gpu_path(&self) -> String;
-
-    fn name(&self) -> String;
-    fn path(&self) -> String;
-    fn class(&self) -> String;
-    fn class_id(&self) -> String;
-    fn vendor(&self) -> String;
-    fn vendor_id(&self) -> String;
-    fn device(&self) -> String;
-    fn device_id(&self) -> String;
-    fn subdevice(&self) -> String;
-    fn subdevice_id(&self) -> String;
-    fn subvendor_id(&self) -> String;
-    fn revision_id(&self) -> String;
-    fn clock_limit_mhz_min(&self) -> GPUResult<f64>;
-    fn clock_limit_mhz_max(&self) -> GPUResult<f64>;
-    fn clock_value_mhz_min(&self) -> GPUResult<f64>;
-    fn set_clock_value_mhz_min(&mut self, value: f64) -> GPUResult<()>;
-    fn clock_value_mhz_max(&self) -> GPUResult<f64>;
-    fn set_clock_value_mhz_max(&mut self, value: f64) -> GPUResult<()>;
-    fn manual_clock(&self) -> GPUResult<bool>;
-    fn set_manual_clock(&mut self, enabled: bool) -> GPUResult<()>;
+    async fn get_gpu_path(&self) -> String;
+    
+    async fn name(&self) -> String;
+    async fn path(&self) -> String;
+    async fn class(&self) -> String;
+    async fn class_id(&self) -> String;
+    async fn vendor(&self) -> String;
+    async fn vendor_id(&self) -> String;
+    async fn device(&self) -> String;
+    async fn device_id(&self) -> String;
+    async fn subdevice(&self) -> String;
+    async fn subdevice_id(&self) -> String;
+    async fn subvendor_id(&self) -> String;
+    async fn revision_id(&self) -> String;
+    async fn clock_limit_mhz_min(&self) -> GPUResult<f64>;
+    async fn clock_limit_mhz_max(&self) -> GPUResult<f64>;
+    async fn clock_value_mhz_min(&self) -> GPUResult<f64>;
+    async fn set_clock_value_mhz_min(&mut self, value: f64) -> GPUResult<()>;
+    async fn clock_value_mhz_max(&self) -> GPUResult<f64>;
+    async fn set_clock_value_mhz_max(&mut self, value: f64) -> GPUResult<()>;
+    async fn manual_clock(&self) -> GPUResult<bool>;
+    async fn set_manual_clock(&mut self, enabled: bool) -> GPUResult<()>;
 }

--- a/src/performance/gpu/interface.rs
+++ b/src/performance/gpu/interface.rs
@@ -1,5 +1,8 @@
-use std::sync::{Arc, Mutex};
-use crate::performance::gpu::tdp::TDPDevice;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::performance::gpu::dbus::devices::TDPDevices;
 
 pub enum GPUError {
     //FeatureUnsupported,
@@ -19,7 +22,7 @@ pub type GPUResult<T> = Result<T, GPUError>;
 /// Represents the data contained in /sys/class/drm/cardX
 pub trait GPUIface: Send + Sync {
 
-    fn get_tdp_interface(&self) -> Option<Arc<Mutex<dyn TDPDevice>>>;
+    fn get_tdp_interface(&self) -> Option<Arc<Mutex<TDPDevices>>>;
 
     fn get_gpu_path(&self) -> String;
 

--- a/src/performance/gpu/tdp.rs
+++ b/src/performance/gpu/tdp.rs
@@ -14,14 +14,12 @@ impl Into<String> for TDPError {
 pub type TDPResult<T> = Result<T, TDPError>;
 
 pub trait TDPDevice : Sync + Send {
-
-    fn tdp(&self) -> TDPResult<f64>;
-    fn set_tdp(&mut self, value: f64) -> TDPResult<()>;
-    fn boost(&self) -> TDPResult<f64>;
-    fn set_boost(&mut self, value: f64) -> TDPResult<()>;
-    fn thermal_throttle_limit_c(&self) -> TDPResult<f64>;
-    fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()>;
-    fn power_profile(&self) -> TDPResult<String>;
-    fn set_power_profile(&mut self, profile: String) -> TDPResult<()>;
-
+    async fn tdp(&self) -> TDPResult<f64>;
+    async fn set_tdp(&mut self, value: f64) -> TDPResult<()>;
+    async fn boost(&self) -> TDPResult<f64>;
+    async fn set_boost(&mut self, value: f64) -> TDPResult<()>;
+    async fn thermal_throttle_limit_c(&self) -> TDPResult<f64>;
+    async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()>;
+    async fn power_profile(&self) -> TDPResult<String>;
+    async fn set_power_profile(&mut self, profile: String) -> TDPResult<()>;
 }


### PR DESCRIPTION
This makes GPU dbus interface fully async and therefore allows usage of async functions inside dbus logic without crashing the runtime.

This is needed since lots of crates are async and the future asus work will need this.

This PR is a rework of my in-development asus-specific device and needs testing before merging.