### PR TITLE
fix(ARM): exclude ryzenadj if running on non-x86_64 hardware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ dbus = "*"
 pciutils = "*"
 
 [dependencies]
-libryzenadj = { git = "https://gitlab.com/shadowapex/libryzenadj-rs.git" }
 log = "0.4.20"
 simple_logger = "4.2.0"
 tokio = { version = "*", features = ["full"] }
@@ -25,6 +24,9 @@ zbus = { version = "3.14.1", default-features = false, features = ["tokio"] }
 zbus_macros = "3.14.1"
 rog_platform = { git = "https://gitlab.com/asus-linux/asusctl.git", default-features = true }
 xdg = "2.5.2"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+libryzenadj = { git = "https://gitlab.com/shadowapex/libryzenadj-rs.git" }
 
 [profile.release]
 debug = false

--- a/src/performance/gpu/amd/ryzenadj.rs
+++ b/src/performance/gpu/amd/ryzenadj.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "x86_64")]
 use std::error::Error;
 
 use libryzenadj::RyzenAdj;

--- a/src/performance/gpu/amd/tdp.rs
+++ b/src/performance/gpu/amd/tdp.rs
@@ -4,12 +4,14 @@ use crate::performance::gpu::{
     tdp::{TDPDevice, TDPError, TDPResult},
 };
 
+#[cfg(target_arch = "x86_64")]
 use super::ryzenadj::RyzenAdjTdp;
 
 /// Implementation of TDP control for AMD GPUs
 pub struct Tdp {
     asus_wmi: Option<AsusWmi>,
     acpi: Option<Acpi>,
+    #[cfg(target_arch = "x86_64")]
     ryzenadj: Option<RyzenAdjTdp>,
 }
 
@@ -31,6 +33,7 @@ impl Tdp {
             None => None,
         };
 
+        #[cfg(target_arch = "x86_64")]
         let ryzenadj = match RyzenAdjTdp::new(path.to_string(), device_id.to_string()) {
             Ok(ryzenadj) => {
                 log::info!("Found RyzenAdj interface for TDP control");
@@ -45,6 +48,7 @@ impl Tdp {
         Tdp {
             asus_wmi,
             acpi,
+            #[cfg(target_arch = "x86_64")]
             ryzenadj,
         }
     }
@@ -68,6 +72,7 @@ impl TDPDevice for Tdp {
             };
         };
         // TODO: set platform profile based on % of max TDP.
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_ref().unwrap();
             match ryzenadj.tdp().await {
@@ -99,6 +104,7 @@ impl TDPDevice for Tdp {
                 }
             };
         };
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_mut().unwrap();
             match ryzenadj.set_tdp(value).await {
@@ -130,6 +136,7 @@ impl TDPDevice for Tdp {
                 }
             };
         };
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_ref().unwrap();
             match ryzenadj.boost().await {
@@ -161,6 +168,7 @@ impl TDPDevice for Tdp {
                 }
             };
         };
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_mut().unwrap();
             match ryzenadj.set_boost(value).await {
@@ -180,6 +188,7 @@ impl TDPDevice for Tdp {
 
     async fn thermal_throttle_limit_c(&self) -> TDPResult<f64> {
         log::info!("Get tctl limit");
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_ref().unwrap();
             match ryzenadj.thermal_throttle_limit_c().await {
@@ -199,6 +208,7 @@ impl TDPDevice for Tdp {
 
     async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> TDPResult<()> {
         log::info!("Set tctl limit");
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_mut().unwrap();
             match ryzenadj.set_thermal_throttle_limit_c(limit).await {
@@ -231,6 +241,7 @@ impl TDPDevice for Tdp {
             };
         };
 
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_ref().unwrap();
             match ryzenadj.power_profile().await {
@@ -263,6 +274,7 @@ impl TDPDevice for Tdp {
             };
         };
 
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_mut().unwrap();
             match ryzenadj.set_power_profile(profile.clone()).await {
@@ -293,6 +305,7 @@ impl TDPDevice for Tdp {
                 }
             };
         };
+        #[cfg(target_arch = "x86_64")]
         if self.ryzenadj.is_some() {
             let ryzenadj = self.ryzenadj.as_ref().unwrap();
             match ryzenadj.power_profiles_available().await {


### PR DESCRIPTION
This change adds conditional compilation settings to exclude ryzenadj if PowerStation is built for non-x86_64 architectures.