### PR TITLE
fix(ryzenadj): add refresh before get limit

### DIFF
--- a/src/performance/gpu/amd/ryzenadj.rs
+++ b/src/performance/gpu/amd/ryzenadj.rs
@@ -79,6 +79,11 @@ impl RyzenAdjTdp {
     // Get the PPT slow limit
     fn get_ppt_limit_slow(&self) -> Result<f32, String> {
         log::debug!("Getting ppt slow limit");
+        
+        if let Err(e) = self.ryzenadj.refresh() {
+            log::error!("Failed to refresh ryzenadj: {}", e);
+        }
+
         match self.ryzenadj.get_slow_limit() {
             Ok(x) => Ok(x),
             Err(e) => {
@@ -116,6 +121,10 @@ impl RyzenAdjTdp {
         // attribute.
         if self.is_unsupported_gpu() {
             return Ok(self.unsupported_ppt_limit_fast);
+        }
+
+        if let Err(e) = self.ryzenadj.refresh() {
+            log::error!("Failed to refresh ryzenadj: {}", e);
         }
 
         // Get the fast limit from ryzenadj
@@ -162,6 +171,10 @@ impl RyzenAdjTdp {
             return Ok(self.unsupported_stapm_limit);
         }
 
+        if let Err(e) = self.ryzenadj.refresh() {
+            log::error!("Failed to refresh ryzenadj: {}", e);
+        }
+
         // Get the value from ryzenadj
         match self.ryzenadj.get_stapm_limit() {
             Ok(x) => {
@@ -204,6 +217,10 @@ impl RyzenAdjTdp {
         // attribute.
         if self.is_unsupported_gpu() {
             return Ok(self.unsupported_thm_limit);
+        }
+
+        if let Err(e) = self.ryzenadj.refresh() {
+            log::error!("Failed to refresh ryzenadj: {}", e);
         }
 
         // Get the value from ryzenadj


### PR DESCRIPTION
It seems that by default, the limit value read by libryzenadj is cached, causing subsequent inability to read the real-time limit value.
```
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z INFO  [powerstation::performance::gpu::amd::tdp] Set TDP
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting TDP to: 15
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting ppt slow limit
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 28.000002
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting stapm limit to 15000
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Set stapm limit to 15000
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting boost to: 0
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 28.000002
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting slow ppt limit to 28000
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting fast ppt limit to 35000
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z INFO  [powerstation::performance::gpu::amd::tdp] TDP set to 15
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z INFO  [powerstation::performance::gpu::amd::tdp] Get TDP
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.980Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.981Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 28.000002
4月 22 20:21:27 G1617-01 powerstation[53890]: 2025-04-22T12:21:27.981Z INFO  [powerstation::performance::gpu::amd::tdp] TDP is currently 28.000001907348633
```
By performing a refresh operation before obtaining the limit value, the issue is resolved.

```
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.165Z INFO  [powerstation::performance::gpu::amd::tdp] Set TDP
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.165Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting TDP to: 10
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.165Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting ppt slow limit
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.165Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.166Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 10
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.166Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting stapm limit to 10000
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.166Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Set stapm limit to 10000
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.166Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting boost to: 0
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.166Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 10
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting slow ppt limit to 10000
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Setting fast ppt limit to 12500
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z INFO  [powerstation::performance::gpu::amd::tdp] TDP set to 10
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z INFO  [powerstation::performance::gpu::amd::tdp] Get TDP
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.167Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Getting stapm limit
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.179Z DEBUG [powerstation::performance::gpu::amd::ryzenadj] Got stapm limit: 10
4月 22 20:47:59 G1617-01 powerstation[68422]: 2025-04-22T12:47:59.179Z INFO  [powerstation::performance::gpu::amd::tdp] TDP is currently 10

```