### PR TITLE
fix: add aarch64 cross compilation support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: 🪲 Test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   run-tests:
@@ -11,3 +11,21 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           make in-docker TARGET='test'
+
+  build-x86_64:
+    name: Run x86_64 build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          make in-docker TARGET='dist' BUILD_TYPE='debug'
+
+  build-aarch64:
+    name: Run aarch64 build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          make in-docker TARGET='dist' BUILD_TYPE='debug' TARGET_ARCH='aarch64-unknown-linux-gnu'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -33,7 +33,9 @@ plugins:
   # Execute commands to build the project
   - - "@semantic-release/exec"
     - shell: true
-      prepareCmd: "make in-docker TARGET='dist'"
+      prepareCmd: |
+        make in-docker TARGET='dist'
+        make in-docker TARGET='dist' TARGET_ARCH="aarch64-unknown-linux-gnu"
 
   # Commit the following changes to git after other plugins have run
   - - "@semantic-release/git"
@@ -46,5 +48,5 @@ plugins:
     - assets:
         - path: dist/powerstation-*.rpm
         - path: dist/powerstation-*.rpm.sha256.txt
-        - path: dist/powerstation.tar.gz
-        - path: dist/powerstation.tar.gz.sha256.txt
+        - path: dist/powerstation-*.tar.gz
+        - path: dist/powerstation-*.tar.gz.sha256.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Daemon for controlling TDP and performance over DBus"
 
 [package.metadata.generate-rpm]
 assets = [
-  { source = "./target/release/powerstation", dest = "/usr/bin/powerstation", mode = "755" },
+  { source = "target/release/powerstation", dest = "/usr/bin/powerstation", mode = "755" },
   { source = "./rootfs/usr/share/dbus-1/system.d/org.shadowblip.PowerStation.conf", dest = "/usr/share/dbus-1/system.d/org.shadowblip.PowerStation.conf", mode = "644" },
   { source = "./rootfs/usr/lib/systemd/system/powerstation.service", dest = "/usr/lib/systemd/system/powerstation.service", mode = "644" },
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
-FROM rust:1.83
+FROM rust:1.86
 
+RUN dpkg --add-architecture arm64
 RUN apt-get update && apt-get install -y \
 	cmake \
 	build-essential \
 	libpci-dev \
 	libclang-15-dev
+
+RUN apt-get install -y \
+  g++-aarch64-linux-gnu \
+  libc6-dev-arm64-cross \
+  libpci-dev:arm64
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+ENV CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++


### PR DESCRIPTION
This change updates the build to use Rust v1.86 and adds cross-compiling of the arm64 binary.