### PR TITLE
fix(dmi_overrides): reduce max TDP for Ayaneo 2S-based devices

### DIFF
--- a/rootfs/usr/share/powerstation/platform/dmi_overrides_apu_database.toml
+++ b/rootfs/usr/share/powerstation/platform/dmi_overrides_apu_database.toml
@@ -37,19 +37,19 @@ max_boost = 0.0
 [[models]]
 model_name = "AYANEO 2S"
 min_tdp = 5.0
-max_tdp = 25.0
+max_tdp = 20.0
 max_boost = 0.0
 
 [[models]]
 model_name = "GEEK 1S"
 min_tdp = 5.0
-max_tdp = 25.0
+max_tdp = 20.0
 max_boost = 0.0
 
 [[models]]
 model_name = "SuiPlay0X1"
 min_tdp = 5.0
-max_tdp = 25.0
+max_tdp = 20.0
 max_boost = 0.0
 
 [[models]]


### PR DESCRIPTION
I have seen cases of overheating when using a TDP value of 25 on the Ayaneo 2S. This change reduces the maximum TDP to a more appropriate value.