### PR TITLE
fix: update all dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,21 +43,11 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
-dependencies = [
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-broadcast"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -83,40 +73,9 @@ checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.5.0",
+ "fastrand",
+ "futures-lite",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock 3.4.0",
- "blocking",
- "futures-lite 2.5.0",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
 ]
 
 [[package]]
@@ -125,26 +84,17 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite",
  "parking",
- "polling 3.7.4",
- "rustix 0.38.42",
+ "polling",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -153,26 +103,9 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
-dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-signal",
- "blocking",
- "cfg-if",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.42",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -182,15 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
- "rustix 0.38.42",
+ "event-listener",
+ "futures-lite",
+ "rustix",
  "tracing",
 ]
 
@@ -202,7 +135,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -211,13 +144,13 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.42",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -237,7 +170,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -286,7 +219,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.90",
+ "syn",
  "which",
 ]
 
@@ -303,15 +236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +244,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite",
  "piper",
 ]
 
@@ -335,12 +259,6 @@ name = "bytecount"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -429,7 +347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -448,29 +366,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "deranged"
@@ -479,27 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -532,7 +410,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -553,23 +431,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -585,17 +446,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -618,79 +470,15 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
-dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
  "pin-project-lite",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -794,15 +582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,9 +631,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -911,12 +690,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -933,24 +706,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -1001,27 +765,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -1078,7 +830,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1162,19 +914,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -1186,22 +932,6 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
@@ -1210,7 +940,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.42",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1234,17 +964,8 @@ dependencies = [
  "toml",
  "udev 0.9.3",
  "xdg",
- "zbus 3.15.2",
- "zbus_macros 3.15.2",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
+ "zbus",
+ "zbus_macros",
 ]
 
 [[package]]
@@ -1254,7 +975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1273,7 +994,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1292,36 +1013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1374,7 +1065,7 @@ dependencies = [
  "serde",
  "typeshare",
  "udev 0.8.0",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -1401,20 +1092,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
@@ -1422,7 +1099,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -1440,22 +1117,22 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1478,27 +1155,16 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1518,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "4.3.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
 dependencies = [
  "colored",
  "log",
@@ -1545,16 +1211,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
@@ -1568,17 +1224,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1598,9 +1243,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.3.0",
+ "fastrand",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1621,7 +1266,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1659,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1670,7 +1315,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -1678,32 +1323,32 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -1715,22 +1360,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "toml_write",
+ "winnow 0.7.11",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1751,7 +1403,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1762,12 +1414,6 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typeshare"
@@ -1788,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn",
 ]
 
 [[package]]
@@ -1822,7 +1468,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "winapi",
 ]
@@ -1838,18 +1484,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "wasi"
@@ -1878,7 +1512,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1900,7 +1534,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1920,7 +1554,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
 ]
 
 [[package]]
@@ -2113,250 +1747,117 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "zbus"
-version = "3.15.2"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
 dependencies = [
- "async-broadcast 0.5.1",
- "async-process 1.8.1",
- "async-recursion",
- "async-trait",
- "byteorder",
- "derivative",
- "enumflags2",
- "event-listener 2.5.3",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.26.4",
- "once_cell",
- "ordered-stream",
- "rand",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tokio",
- "tracing",
- "uds_windows",
- "winapi",
- "xdg-home",
- "zbus_macros 3.15.2",
- "zbus_names 2.6.1",
- "zvariant 3.15.2",
-]
-
-[[package]]
-name = "zbus"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1162094dc63b1629fcc44150bcceeaa80798cd28bcbe7fa987b65a034c258608"
-dependencies = [
- "async-broadcast 0.7.1",
+ "async-broadcast",
  "async-executor",
- "async-fs",
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "async-process 2.3.0",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-core",
- "futures-util",
+ "futures-lite",
  "hex",
- "nix 0.29.0",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",
- "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow 0.6.20",
- "xdg-home",
- "zbus_macros 5.1.1",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
+ "winnow 0.7.11",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "3.15.2"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "regex",
- "syn 1.0.109",
- "zvariant_utils 1.0.1",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd2dcdce3e2727f7d74b7e33b5a89539b3cc31049562137faf7ae4eb86cd16d"
+checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
- "zvariant_utils 3.0.2",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.6.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant 3.15.2",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b7a38811f71846fd47856ceee8bccaec8399ff53fb370247e66081ace647b"
-dependencies = [
- "serde",
- "static_assertions",
- "winnow 0.6.20",
- "zvariant 5.1.0",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
+ "winnow 0.7.11",
+ "zvariant",
 ]
 
 [[package]]
 name = "zvariant"
-version = "3.15.2"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
-dependencies = [
- "byteorder",
- "enumflags2",
- "libc",
- "serde",
- "static_assertions",
- "zvariant_derive 3.15.2",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1200ee6ac32f1e5a312e455a949a4794855515d34f9909f4a3e082d14e1a56f"
+checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
- "winnow 0.6.20",
- "zvariant_derive 5.1.0",
- "zvariant_utils 3.0.2",
+ "winnow 0.7.11",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.2"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "zvariant_utils 1.0.1",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687e3b97fae6c9104fbbd36c73d27d149abf04fb874e2efbd84838763daa8916"
+checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
- "zvariant_utils 3.0.2",
+ "syn",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d1d011a38f12360e5fcccceeff5e2c42a8eb7f27f0dcba97a0862ede05c9c6"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.90",
- "winnow 0.6.20",
+ "syn",
+ "winnow 0.7.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ dbus = "*"
 pciutils = "*"
 
 [dependencies]
-log = "0.4.20"
-simple_logger = "4.2.0"
-tokio = { version = "*", features = ["full"] }
-zbus = { version = "3.14.1", default-features = false, features = ["tokio"] }
-zbus_macros = "3.14.1"
+log = "0.4.27"
+simple_logger = "5.0.0"
+tokio = { version = "1.45.1", features = ["full"] }
+zbus = { version = "5.7.1", default-features = false, features = ["tokio"] }
+zbus_macros = "5.7.1"
 rog_platform = { git = "https://gitlab.com/asus-linux/asusctl.git", default-features = true }
-xdg = "2.5.2"
-toml = "0.7.8"
-serde = { version = "1.0", features = ["derive"] }
+xdg = "3.0.0"
+toml = "0.8.23"
+serde = { version = "1.0.219", features = ["derive"] }
 udev = { version = "0.9.3", features = ["send", "sync"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/performance/cpu/core.rs
+++ b/src/performance/cpu/core.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use tokio::io::AsyncWriteExt;
 use zbus::fdo;
-use zbus_macros::dbus_interface;
+use zbus_macros::interface;
 
 // Instance of a single CPU core
 #[derive(Debug)]
@@ -42,17 +42,17 @@ impl CPUCore {
     }
 }
 
-#[dbus_interface(name = "org.shadowblip.CPU.Core")]
+#[interface(name = "org.shadowblip.CPU.Core")]
 impl CPUCore {
     // Returns the core number of the CPU core
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub fn number(&self) -> u32 {
         self.number
     }
 
     // Returns the core ID of the CPU core. This ID will be identical for
     // hyperthread cores.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub fn core_id(&self) -> fdo::Result<u32> {
         let path = format!("{0}/topology/core_id", self.path);
         let result = fs::read_to_string(path);
@@ -72,7 +72,7 @@ impl CPUCore {
     }
 
     // Returns true if the given core is online
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub fn online(&self) -> fdo::Result<bool> {
         if self.number == 0 {
             return Ok(true);
@@ -89,7 +89,7 @@ impl CPUCore {
     }
 
     // Sets the given core to online
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub fn set_online(&mut self, enabled: bool) -> fdo::Result<()> {
         let enabled_str = if enabled { "enabled" } else { "disabled" };
         log::info!("Setting core {} to {}", self.number, enabled_str);

--- a/src/performance/cpu/cpu_features.rs
+++ b/src/performance/cpu/cpu_features.rs
@@ -3,7 +3,7 @@ use std::{fs::OpenOptions, io::Write};
 use tokio::fs;
 use zbus::fdo;
 use zbus::zvariant::ObjectPath;
-use zbus_macros::dbus_interface;
+use zbus_macros::interface;
 
 use crate::constants::CPU_PATH;
 use crate::performance::cpu::core::CPUCore;
@@ -57,10 +57,10 @@ impl Cpu {
     }
 }
 
-#[dbus_interface(name = "org.shadowblip.CPU")]
+#[interface(name = "org.shadowblip.CPU")]
 impl Cpu {
     // Returns whether or not boost is enabled
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn boost_enabled(&self) -> fdo::Result<bool> {
         if !has_feature("cpb".to_string()).await? {
             return Ok(false);
@@ -77,7 +77,7 @@ impl Cpu {
     }
 
     // Set whether or not boost is enabled
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn set_boost_enabled(&mut self, enabled: bool) -> fdo::Result<()> {
         log::info!("Setting boost enabled to {}", enabled);
         let status = if enabled { "1" } else { "0" };
@@ -97,7 +97,7 @@ impl Cpu {
     }
 
     // Returns whether or not SMT is currently enabled
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn smt_enabled(&self) -> fdo::Result<bool> {
         if !has_feature("ht".to_string()).await? {
             return Ok(false);
@@ -114,7 +114,7 @@ impl Cpu {
     }
 
     // Set whether or not SMT is enabled
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn set_smt_enabled(&mut self, enabled: bool) -> fdo::Result<()> {
         log::info!("Setting smt enabled to {}", enabled);
         let status = if enabled { "on" } else { "off" };
@@ -134,18 +134,18 @@ impl Cpu {
     }
 
     // Returns a list of features that the CPU supports
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn features(&self) -> fdo::Result<Vec<String>> {
         get_features().await
     }
 
     /// Returns the total number of CPU cores detected
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn cores_count(&self) -> fdo::Result<u32> {
         Ok(self.core_count)
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn cores_enabled(&self) -> fdo::Result<u32> {
         let mut count = 0;
         for core_list in self.core_map.values() {
@@ -159,7 +159,7 @@ impl Cpu {
         Ok(count)
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn set_cores_enabled(&mut self, num: u32) -> fdo::Result<()> {
         log::info!("Setting core count to {}", num);
         if num < 1 {

--- a/src/performance/gpu/connector.rs
+++ b/src/performance/gpu/connector.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use zbus::fdo;
-use zbus_macros::dbus_interface;
+use zbus_macros::interface;
 
 /// Represents the data contained in /sys/class/drm/cardX-YYYY
 pub struct Connector {
@@ -8,19 +8,19 @@ pub struct Connector {
     pub path: String,
 }
 
-#[dbus_interface(name = "org.shadowblip.GPU.Card.Connector")]
+#[interface(name = "org.shadowblip.GPU.Card.Connector")]
 impl Connector {
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn name(&self) -> String {
         self.name.clone()
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn path(&self) -> String {
         self.path.clone()
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn id(&self) -> fdo::Result<u32> {
         let path = format!("{0}/{1}", self.path(), "connector_id");
         let result = fs::read_to_string(path);
@@ -38,7 +38,7 @@ impl Connector {
         Ok(id)
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn enabled(&self) -> fdo::Result<bool> {
         let path = format!("{0}/{1}", self.path(), "enabled");
         let result = fs::read_to_string(path);
@@ -51,7 +51,7 @@ impl Connector {
         Ok(status == "enabled")
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn modes(&self) -> fdo::Result<Vec<String>> {
         let mut modes: Vec<String> = Vec::new();
         let path = format!("{0}/{1}", self.path(), "modes");
@@ -71,7 +71,7 @@ impl Connector {
         Ok(modes)
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn status(&self) -> fdo::Result<String> {
         let path = format!("{0}/{1}", self.path(), "status");
         let result = fs::read_to_string(path);
@@ -84,7 +84,7 @@ impl Connector {
         Ok(status)
     }
 
-    #[dbus_interface(property, name = "DPMS")]
+    #[zbus(property, name = "DPMS")]
     fn dpms(&self) -> fdo::Result<bool> {
         let path = format!("{0}/{1}", self.path(), "dpms");
         let result = fs::read_to_string(path);

--- a/src/performance/gpu/dbus/devices.rs
+++ b/src/performance/gpu/dbus/devices.rs
@@ -8,6 +8,7 @@ use crate::performance::gpu::{
     tdp::{TDPDevice, TDPResult},
 };
 
+#[allow(clippy::large_enum_variant)]
 pub enum TDPDevices {
     Amd(amd::tdp::Tdp),
     Intel(intel::tdp::Tdp),

--- a/src/performance/gpu/dbus/gpu.rs
+++ b/src/performance/gpu/dbus/gpu.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use zbus::fdo;
 use zbus::zvariant::ObjectPath;
-use zbus_macros::dbus_interface;
+use zbus_macros::interface;
 
 use tokio::sync::Mutex;
 
@@ -62,7 +62,7 @@ impl GPUDBusInterface {
     }
 }
 
-#[dbus_interface(name = "org.shadowblip.GPU.Card")]
+#[interface(name = "org.shadowblip.GPU.Card")]
 impl GPUDBusInterface {
     /// Returns a list of DBus paths to all connectors
     pub fn enumerate_connectors(&self) -> fdo::Result<Vec<ObjectPath>> {
@@ -73,67 +73,67 @@ impl GPUDBusInterface {
             .collect())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     pub async fn name(&self) -> String {
         self.gpu_obj.lock().await.name().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn path(&self) -> String {
         self.gpu_obj.lock().await.path().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn class(&self) -> String {
         self.gpu_obj.lock().await.class().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn class_id(&self) -> String {
         self.gpu_obj.lock().await.class_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn vendor(&self) -> String {
         self.gpu_obj.lock().await.vendor().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn vendor_id(&self) -> String {
         self.gpu_obj.lock().await.vendor_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn device(&self) -> String {
         self.gpu_obj.lock().await.device().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn device_id(&self) -> String {
         self.gpu_obj.lock().await.device_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn subdevice(&self) -> String {
         self.gpu_obj.lock().await.subdevice().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn subdevice_id(&self) -> String {
         self.gpu_obj.lock().await.subdevice_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn subvendor_id(&self) -> String {
         self.gpu_obj.lock().await.subvendor_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn revision_id(&self) -> String {
         self.gpu_obj.lock().await.revision_id().await
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn clock_limit_mhz_min(&self) -> fdo::Result<f64> {
         self.gpu_obj
             .lock()
@@ -143,7 +143,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn clock_limit_mhz_max(&self) -> fdo::Result<f64> {
         self.gpu_obj
             .lock()
@@ -153,7 +153,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn clock_value_mhz_min(&self) -> fdo::Result<f64> {
         self.gpu_obj
             .lock()
@@ -163,7 +163,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_clock_value_mhz_min(&mut self, value: f64) -> fdo::Result<()> {
         self.gpu_obj
             .lock()
@@ -173,7 +173,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn clock_value_mhz_max(&self) -> fdo::Result<f64> {
         self.gpu_obj
             .lock()
@@ -183,7 +183,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_clock_value_mhz_max(&mut self, value: f64) -> fdo::Result<()> {
         self.gpu_obj
             .lock()
@@ -193,7 +193,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn manual_clock(&self) -> fdo::Result<bool> {
         self.gpu_obj
             .lock()
@@ -203,7 +203,7 @@ impl GPUDBusInterface {
             .map_err(|err| err.into())
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_manual_clock(&mut self, enabled: bool) -> fdo::Result<()> {
         self.gpu_obj
             .lock()
@@ -228,7 +228,7 @@ impl GPUBus {
     }
 }
 
-#[dbus_interface(name = "org.shadowblip.GPU")]
+#[interface(name = "org.shadowblip.GPU")]
 impl GPUBus {
     /// Returns a list of DBus paths to all GPU cards
     pub async fn enumerate_cards(&self) -> fdo::Result<Vec<ObjectPath>> {
@@ -468,10 +468,7 @@ pub fn get_connectors(gpu_name: String) -> Vec<Connector> {
 
 /// Returns the path to the PCI id's file from hwdata
 fn get_pci_ids_path() -> PathBuf {
-    let Ok(base_dirs) = xdg::BaseDirectories::with_prefix("hwdata") else {
-        log::warn!("Unable to determine config base path. Using fallback path.");
-        return PathBuf::from(PCI_IDS_PATH);
-    };
+    let base_dirs = xdg::BaseDirectories::with_prefix("hwdata");
 
     // Get the data directories in preference order
     let data_dirs = base_dirs.get_data_dirs();

--- a/src/performance/gpu/dbus/tdp.rs
+++ b/src/performance/gpu/dbus/tdp.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use zbus::fdo;
-use zbus_macros::dbus_interface;
+use zbus_macros::interface;
 
 use tokio::sync::Mutex;
 
@@ -29,10 +29,10 @@ impl GPUTDPDBusIface {
     }
 }
 
-#[dbus_interface(name = "org.shadowblip.GPU.Card.TDP")]
+#[interface(name = "org.shadowblip.GPU.Card.TDP")]
 impl GPUTDPDBusIface {
     /// Get the currently set TDP value
-    #[dbus_interface(property, name = "TDP")]
+    #[zbus(property, name = "TDP")]
     async fn tdp(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.tdp().await {
             TDPResult::Ok(result) => Ok(result),
@@ -41,7 +41,7 @@ impl GPUTDPDBusIface {
     }
 
     /// Sets the given TDP value
-    #[dbus_interface(property, name = "TDP")]
+    #[zbus(property, name = "TDP")]
     async fn set_tdp(&mut self, value: f64) -> fdo::Result<()> {
         match self.dev.lock().await.set_tdp(value).await {
             TDPResult::Ok(result) => Ok(result),
@@ -49,7 +49,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn min_tdp(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.min_tdp().await {
             TDPResult::Ok(result) => Ok(result),
@@ -57,7 +57,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn max_tdp(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.max_tdp().await {
             TDPResult::Ok(result) => Ok(result),
@@ -67,7 +67,7 @@ impl GPUTDPDBusIface {
 
     /// The TDP boost for AMD is the total difference between the Fast PPT Limit
     /// and the STAPM limit.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn boost(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.boost().await {
             TDPResult::Ok(result) => Ok(result),
@@ -75,7 +75,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn max_boost(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.max_boost().await {
             TDPResult::Ok(result) => Ok(result),
@@ -83,7 +83,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_boost(&mut self, value: f64) -> fdo::Result<()> {
         match self.dev.lock().await.set_boost(value).await {
             TDPResult::Ok(result) => Ok(result),
@@ -91,7 +91,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn thermal_throttle_limit_c(&self) -> fdo::Result<f64> {
         match self.dev.lock().await.thermal_throttle_limit_c().await {
             TDPResult::Ok(result) => Ok(result),
@@ -99,7 +99,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_thermal_throttle_limit_c(&mut self, limit: f64) -> fdo::Result<()> {
         match self
             .dev
@@ -113,7 +113,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn power_profile(&self) -> fdo::Result<String> {
         match self.dev.lock().await.power_profile().await {
             TDPResult::Ok(result) => Ok(result),
@@ -121,7 +121,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_power_profile(&mut self, profile: String) -> fdo::Result<()> {
         match self.dev.lock().await.set_power_profile(profile).await {
             TDPResult::Ok(result) => Ok(result),
@@ -129,7 +129,7 @@ impl GPUTDPDBusIface {
         }
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn power_profiles_available(&self) -> fdo::Result<Vec<String>> {
         match self.dev.lock().await.power_profiles_available().await {
             TDPResult::Ok(result) => Ok(result),


### PR DESCRIPTION
This change updates all Cargo dependencies and makes the necessary changes to upgrade zbus from v3.x to v5.x