### PR TITLE
Add AMD Ryzen AI MAX+ 395 model to database

### DIFF
--- a/rootfs/usr/share/powerstation/platform/amd_apu_database.toml
+++ b/rootfs/usr/share/powerstation/platform/amd_apu_database.toml
@@ -561,3 +561,9 @@ model_name = "AMD Ryzen 3 8540U w/ Radeon 740M Graphics"
 min_tdp = 5.0
 max_tdp = 30.0
 max_boost = 0.0
+
+[[models]]
+model_name = "AMD Ryzen AI MAX+ 395"
+min_tdp = 5.0
+max_tdp = 90.0
+max_boost = 5.1


### PR DESCRIPTION
Adding the AMD Ryzen AI MAX+ 395.

The APU's max TDP is technically 120w on devices like the Apex and Super X if you have appropriate cooing (Frost Bay), but not all devices support that.