### PR TITLE
feat: add ONEXPLAYER 3 TDP support

### DIFF
--- a/rootfs/usr/share/powerstation/platform/dmi_overrides_apu_database.toml
+++ b/rootfs/usr/share/powerstation/platform/dmi_overrides_apu_database.toml
@@ -100,3 +100,9 @@ model_name = "Claw A1M"
 min_tdp = 5.0
 max_tdp = 28.0
 max_boost = 5.0
+
+[[models]]
+model_name = "ONEXPLAYER 3"
+min_tdp = 8.0
+max_tdp = 35.0
+max_boost = 17.0

--- a/src/performance/gpu/intel/tdp.rs
+++ b/src/performance/gpu/intel/tdp.rs
@@ -30,9 +30,17 @@ impl Tdp {
             None => None,
         };
 
-        // Discover the package domain path
+        // Discover the package domain path. Prefer the MMIO interface when it
+        // is available, matching Intel thermald's behavior. Some platforms
+        // expose different limits through the MMIO and MSR interfaces.
         let mut base_path = None;
-        if let Ok(mut rapl_dir) = fs::read_dir("/sys/class/powercap/intel-rapl") {
+        for rapl_path in [
+            "/sys/class/powercap/intel-rapl-mmio",
+            "/sys/class/powercap/intel-rapl",
+        ] {
+            let Ok(mut rapl_dir) = fs::read_dir(rapl_path) else {
+                continue;
+            };
             while let Some(Ok(entry)) = rapl_dir.next() {
                 let Ok(file_type) = entry.file_type() else {
                     continue;
@@ -44,7 +52,7 @@ impl Tdp {
                 let Some(file_name) = file_name.to_str() else {
                     continue;
                 };
-                if !file_name.starts_with("intel-rapl:") {
+                if !file_name.starts_with("intel-rapl") {
                     continue;
                 }
                 let domain_path = entry.path();
@@ -55,7 +63,11 @@ impl Tdp {
                 if !name.as_str().trim().starts_with("package") {
                     continue;
                 }
+                log::info!("Using Intel RAPL package domain: {:?}", domain_path);
                 base_path = Some(domain_path);
+                break;
+            }
+            if base_path.is_some() {
                 break;
             }
         }


### PR DESCRIPTION
## Summary

- Add an ONEXPLAYER 3 DMI override with an 8–35 W TDP range
- Prefer the `intel-rapl-mmio` powercap interface when available
- Fall back to the existing `intel-rapl` interface
- Accept package domains exposed with either RAPL naming scheme
- Log the selected Intel RAPL package domain

## Rationale

The ONEXPLAYER 3 exposes both MMIO and MSR-backed Intel RAPL domains, but they do not provide equivalent writable limits. Using the MMIO package domain matches Intel thermald's preference and allows PowerStation to control the effective platform power limits.

## Testing

- Release build completed successfully
- Live-tested on an ONEXPLAYER 3 running Bazzite 44
- Confirmed 17 W and 35 W settings through the PowerStation D-Bus API
- Confirmed the corresponding MMIO PL1/PL2 limits changed correctly
- Confirmed the original services and power limits were restored after testing

## AI assistance disclosure

This change was developed with assistance from OpenAI Codex. The resulting code was reviewed, built, tested, and validated on physical ONEXPLAYER 3 hardware by me. 